### PR TITLE
Update loc4lize API instance

### DIFF
--- a/data/js/ui.trending_topicsview.js
+++ b/data/js/ui.trending_topicsview.js
@@ -33,7 +33,7 @@ function init_view(view) {
 get_trending_topics_local:
 function get_trending_topics_local(view, success, fail) {
     if (ui.TrendingTopicsView.woeid == null) {
-        $.get('http://loc4lizer.heroku.com/localize.json', function(data) {
+        $.get('http://www.loc4lize.me/localize.json', function(data) {
             ui.TrendingTopicsView.woeid = data.geo.woeid;
             ui.TrendingTopicsView.city = data.geo.city;
             $('.trending_topics_local').html('Local (' + data.geo.city + ')');


### PR DESCRIPTION
Forgot to update loc4lize API instance. The one that will be maintained is www.loc4lize.me instead of Heroku one, that is going to be removed very soon.
