### PR TITLE
Fix 388 - case sensitivity kismet

### DIFF
--- a/data/js/kismet.js
+++ b/data/js/kismet.js
@@ -224,9 +224,11 @@ function eval_bool_exp (exp, incoming) {
 
     // I just convert t0 and t1 to lowercase, to resolve #388.
     // Not sure whether this causes no other problems :-)
+    // The type check is necessary, to avoid problems with
+    // composite rules.
 
-    t0 = t0.toLowerCase();
-    t1 = t1.toLowerCase();
+    if (typeof t0 == "string") t0 = t0.toLowerCase();
+    if (typeof t1 == "string") t1 = t1.toLowerCase();
 
     switch (exp[0]) {
     case kismet.OP_NOT:


### PR DESCRIPTION
I added two lines of code that make the kismet filtering case insensitive. At least, that's what I think I did. I am new to Hotot and javascript, so it is possibly that I just did something stupid.
