### PR TITLE
Fixes #371 - use correct casing for username autocomplete

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -362,6 +362,8 @@
 
 </div><!-- container -->
 
+<!-- The section below is the definition of the 'dialog' where you enter a new status.
+     The scripts for this dialog are in data/js/ui.status_box.js -->
 <section id="status_box" class="closed dialog">
   <div class="dialog_bar">
     <h2 class="dialog_title" data-i18n-text="compose">Compose</h2>

--- a/data/js/ui.status_box.js
+++ b/data/js/ui.status_box.js
@@ -1,3 +1,5 @@
+// ui.status_box.js - contains the logic for the status update dialog box
+
 if (typeof ui == 'undefined') var ui = {};
 ui.StatusBox = {
 
@@ -37,6 +39,7 @@ function get_status_len(status_text) {
     return status_text.replace(ui.Template.reg_link_g, rep_url).length
 },
 
+// This inits all jquery events for the status update dialog box
 init:
 function init () {
     $('#btn_update').click(function(event){
@@ -239,7 +242,8 @@ function init () {
 
     ui.StatusBox.reg_fake_dots = new RegExp('(\\.\\.\\.)|(。。。)', 'g');
     ui.StatusBox.reg_fake_dots2 = new RegExp('(…\\.+)|(…。+)', 'g');
-    
+
+    // setup autocomplete for user name
     widget.autocomplete.connect($('#tbox_status'));
     widget.autocomplete.connect($('#tbox_dm_target'));
 


### PR DESCRIPTION
Instead of appending the part of the username to be autocompleted to
the already typed text, I take out the already typed part, and replace
it by the complete username in the correct casing.
