### PR TITLE
Closes #445 - preferences window now showing for statusnet accounts

### DIFF
--- a/data/js/ui.prefs_dlg.js
+++ b/data/js/ui.prefs_dlg.js
@@ -285,9 +285,14 @@ function load_prefs() {
     $('#chk_prefs_use_media_preview')
         .attr('checked', prefs.use_media_preview)
         .prop('checked', prefs.use_media_preview);
-    $('#chk_prefs_filter_nsfw_media')
-        .attr('checked', prefs.filter_nsfw_media)
-        .prop('checked', prefs.filter_nsfw_media);        
+
+    if (prefs.filter_nsfw_media!=undefined)
+    {
+        $('#chk_prefs_filter_nsfw_media')
+            .attr('checked', prefs.filter_nsfw_media)
+            .prop('checked', prefs.filter_nsfw_media);        
+    }
+
     $('#chk_prefs_use_deleted_mark')
         .attr('checked', prefs.use_deleted_mark)
         .prop('checked', prefs.use_deleted_mark);


### PR DESCRIPTION
This is probably more a workaround than a real fix.

For statusnet accounts, the preferences window crashed because
prefs.filter_nsfw_media was undefined. I don't know why.
I now just skip the code that uses this property when the
property is not defined.
