### PR TITLE
add copy func to context menu in chrome extension

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1550,7 +1550,7 @@ along with this program. If not, see <a target="_blank" href="http://www.gnu.org
 
 <section id="context_menu">
     <ul class="hotot_menu">
-        <li><a id="context_menuitem_copy" class="select_only native_only" title="Copy" href="#" data-i18n-text="copy_to_clipboard">Copy to clipboard</a></li>
+        <li><a id="context_menuitem_copy" class="select_only" title="Copy" href="#" data-i18n-text="copy_to_clipboard">Copy to clipboard</a></li>
         <li><a id="context_menuitem_paste" class="editable_only native_only" title="Paste" href="#" data-i18n-text="paste_from_clipboard">Paste from clipboard</a></li>
         <li><a id="context_menuitem_kismet_username" class="select_only native_only" title="Mute this user" href="#" data-i18n-text="mute_this_user">Mute this user</a></li>
         <li><a id="context_menuitem_kismet_word" class="select_only native_only" title="Mute this word" href="#" data-i18n-text="mute_this_word">Mute this word</a></li>

--- a/data/js/ui.context_menu.js
+++ b/data/js/ui.context_menu.js
@@ -10,7 +10,18 @@ init:
 function init() {
     $('#context_menuitem_copy').click(
     function (event) {
-        hotot_action('action/set_clipboard_text/' + ui.ContextMenu.selected_string);
+        if (!util.is_native_platform()) {
+            if (conf.vars.platform === 'Chrome') {
+                toast.set('Copied!').show(-1);
+                var sandbox = $('#sandbox').val(ui.ContextMenu.selected_string).select();
+                document.execCommand('copy');
+                sandbox.val('');
+            } else {
+                // pass
+            }
+        } else {
+            hotot_action('action/set_clipboard_text/' + ui.ContextMenu.selected_string);
+        }
         if (ui.ContextMenu.event_element) {
             $(ui.ContextMenu.event_element).focus();
         }


### PR DESCRIPTION
copy without using keyboard.
