### PR TITLE
Migrated Twitter API from 1.0 to 1.1

### DIFF
--- a/data/js/lib.twitter.js
+++ b/data/js/lib.twitter.js
@@ -13,6 +13,25 @@ function TwitterClient() {
     self.search_api_base2 = 'https://twitter.com/phoenix_search.phoenix';
     self.upload_api_base = 'https://upload.twitter.com/1/';
 
+    self.api_base_url = function(ver) {
+        if(ver == 1)
+            hotot_log('info', 'Using Deprecated Twitter API');
+
+        if(self.api_base.indexOf('/1/') !== -1) {
+            if(ver == 1.1)
+                return self.api_base.replace('/1/', '/1.1/');
+            else
+                return self.api_base;
+        } else if(self.api_base.indexOf('/1.1/') !== -1) {
+            if(ver == 1)
+                return self.api_base.replace('/1.1/', '/1/');
+            else
+                return self.api_base;
+        } else {
+            return self.api_base + ver;
+        }
+    }
+
     self.use_same_sign_api_base = true;
     self.source = 'Hotot';
 
@@ -138,7 +157,7 @@ function TwitterClient() {
 
     self.do_ajax = function do_ajax(method, url, params, headers, on_success, on_error) {
         params['source'] = self.source;
-        sign_url = self.use_same_sign_api_base ? url: url.replace(self.api_base, self.sign_api_base);
+        sign_url = self.use_same_sign_api_base ? url: url.replace(self.api_base_url(1), self.sign_api_base);
 
         if (self.use_oauth) {
             var signed_params = self.oauth.form_signed_params(
@@ -167,10 +186,10 @@ function TwitterClient() {
     };
 
     self.update_status = function update_status(text, reply_to_id, on_success, on_error) {
-        var url = self.api_base + 'statuses/update.json';
+        var url = self.api_base_url(1.1) + 'statuses/update.json';
         var params = {
             'status': text,
-            'include_entities': '1'
+            'include_entities': '1'     
         };
         if (reply_to_id) {
             params['in_reply_to_status_id'] = reply_to_id;
@@ -227,19 +246,19 @@ function TwitterClient() {
     };
 
     self.retweet_status = function retweet_status(retweet_id, on_success) {
-        var url = self.api_base + 'statuses/retweet/' + retweet_id + '.json';
+        var url = self.api_base_url(1.1) + 'statuses/retweet/' + retweet_id + '.json';
         self.post(url, {},
         on_success);
     };
 
     self.destroy_status = function destroy_status(retweet_id, on_success) {
-        var url = self.api_base + 'statuses/destroy/' + retweet_id + '.json';
+        var url = self.api_base_url(1.1) + 'statuses/destroy/' + retweet_id + '.json';
         self.post(url, {},
         on_success);
     };
 
     self.new_direct_messages = function new_direct_messages(text, user_id, screen_name, on_success, on_error) {
-        var url = self.api_base + 'direct_messages/new.json';
+        var url = self.api_base_url(1.1) + 'direct_messages/new.json';
         var params = {
             'text': text,
             'screen_name': screen_name
@@ -249,25 +268,25 @@ function TwitterClient() {
     };
 
     self.destroy_direct_messages = function destroy_direct_messages(id, on_success) {
-        var url = self.api_base + 'direct_messages/destroy/' + id + '.json';
+        var url = self.api_base_url(1.1) + 'direct_messages/destroy/' + id + '.json';
         self.post(url, {},
         on_success);
     };
 
     self.create_favorite = function create_favorite(fav_id, on_success) {
-        var url = self.api_base + 'favorites/create/' + fav_id + '.json';
+        var url = self.api_base_url(1.1) + 'favorites/create/' + fav_id + '.json';
         self.post(url, {},
         on_success);
     };
 
     self.destroy_favorite = function destroy_favorite(fav_id, on_success) {
-        var url = self.api_base + 'favorites/destroy/' + fav_id + '.json';
+        var url = self.api_base_url(1.1) + 'favorites/destroy/' + fav_id + '.json';
         self.post(url, {},
         on_success);
     };
 
     self.get_home_timeline = function get_home_timeline(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'statuses/home_timeline.json';
+        var url = self.api_base_url(1.1) + 'statuses/home_timeline.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -281,10 +300,10 @@ function TwitterClient() {
     };
 
     self.get_mentions = function get_mentions(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'statuses/mentions.json';
+        var url = self.api_base_url(1.1) + 'statuses/mentions_timeline.json';
         var params = {
             'include_entities': '1',
-            'include_rts': '1',
+            // 'include_rts': '1',      // include_rts has been removed in API v1.1
             'page': '0',
             'count': count
         };
@@ -294,9 +313,10 @@ function TwitterClient() {
         return;
     };
 
-    self.get_favorites = function get_favorites(id, page, on_success) {
-        var url = self.api_base + 'favorites/' + id + '.json';
+    self.get_favorites = function get_favorites(screen_name, page, on_success) {
+        var url = self.api_base_url(1.1) + 'favorites/list.json';
         var params = {
+            'screen_name': screen_name,
             'include_entities': '1',
             'page': page
         };
@@ -305,14 +325,16 @@ function TwitterClient() {
     };
 
     self.get_trending_topics = function get_trending_topics(woeid, on_success) {
-        var url = self.api_base + 'trends/' + woeid + '.json';
-        var params = {};
+        var url = self.api_base_url(1.1) + 'trends/place.json';
+        var params = {
+            'id': woeid,
+        };
         self.get(url, params, on_success);
         return;
     };
 
     self.get_direct_messages = function get_direct_messages(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'direct_messages.json';
+        var url = self.api_base_url(1.1) + 'direct_messages.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -325,7 +347,7 @@ function TwitterClient() {
     };
 
     self.get_sent_direct_messages = function get_sent_direct_messages(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'direct_messages/sent.json';
+        var url = self.api_base_url(1.1) + 'direct_messages/sent.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -338,7 +360,7 @@ function TwitterClient() {
     };
 
     self.get_retweeted_by_me = function get_retweeted_by_me(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'statuses/retweeted_by_me.json';
+        var url = self.api_base_url(1) + 'statuses/retweeted_by_me.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -348,10 +370,12 @@ function TwitterClient() {
         if (max_id != null) params['max_id'] = max_id;
         self.get(url, params, on_success);
         return;
+
+        // has been removed in API v1.1
     };
 
     self.get_retweeted_to_me = function get_retweeted_to_me(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'statuses/retweeted_to_me.json';
+        var url = self.api_base_url(1) + 'statuses/retweeted_to_me.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -361,10 +385,12 @@ function TwitterClient() {
         if (max_id != null) params['max_id'] = max_id;
         self.get(url, params, on_success);
         return;
+
+        // has been removed in API v1.1
     };
 
     self.get_retweets_of_me = function get_retweets_of_me(since_id, max_id, count, on_success) {
-        var url = self.api_base + 'statuses/retweets_of_me.json';
+        var url = self.api_base_url(1.1) + 'statuses/retweets_of_me.json';
         var params = {
             'include_entities': '1',
             'page': '0',
@@ -377,16 +403,19 @@ function TwitterClient() {
     };
 
     self.get_retweeted_by_whom = function get_retweeted_by_whom(tweet_id, count, on_success) {
-        var url = self.api_base + 'statuses/' + tweet_id + '/retweeted_by.json';
+        var url = self.api_base_url(1.1) + 'statuses/retweets/' + tweet_id + '.json';
         var params = {
             'count': count
         };
-        self.get(url, params, on_success);
+        self.get(url, params, function(result, textStatus, xhr) {
+            console.log(result);
+            on_success(result, textStatus, xhr);
+        });
         return;
     };
 
     self.get_user_timeline = function get_user_timeline(user_id, screen_name, since_id, max_id, count, on_success, on_error) {
-        var url = self.api_base + 'statuses/user_timeline.json';
+        var url = self.api_base_url(1.1) + 'statuses/user_timeline.json';
         var params = {
             'include_entities': '1',
             'include_rts': '1',
@@ -402,7 +431,7 @@ function TwitterClient() {
     };
 
     self.show_status = function show_status(id, on_success, on_error) {
-        var url = self.api_base + 'statuses/show/' + id + '.json';
+        var url = self.api_base_url(1.1) + 'statuses/show/' + id + '.json';
         var params = {
             'include_entities': '1'
         };
@@ -410,7 +439,7 @@ function TwitterClient() {
     };
 
     self.show_user = function show_user(screen_name, on_success, on_error) {
-        var url = self.api_base + 'users/show.json';
+        var url = self.api_base_url(1.1) + 'users/show.json';
         var params = {
             'include_entities': '1',
             'screen_name': screen_name
@@ -419,7 +448,7 @@ function TwitterClient() {
     };
 
     self.search_user = function search_user(query, page, on_success, on_error) {
-        var url = self.api_base + 'users/search.json';
+        var url = self.api_base_url(1.1) + 'users/search.json';
         var params = {
             'q': query,
             'page': page,
@@ -430,7 +459,7 @@ function TwitterClient() {
     };
 
     self.get_user_friends = function get_user_friends(screen_name, cursor, on_success) {
-        var url = self.api_base + 'statuses/friends.json';
+        var url = self.api_base_url(1.1) + 'friends/list.json';
         var params = {
             'include_entities': '1',
             'screen_name': screen_name,
@@ -440,7 +469,7 @@ function TwitterClient() {
     };
 
     self.get_user_followers = function get_user_followers(screen_name, cursor, on_success) {
-        var url = self.api_base + 'statuses/followers.json';
+        var url = self.api_base_url(1.1) + 'followers/list.json';
         var params = {
             'include_entities': '1',
             'screen_name': screen_name,
@@ -450,7 +479,7 @@ function TwitterClient() {
     };
 
     self.get_user_friends_ids = function get_user_friends_ids(screen_name, cursor, on_success) {
-        var url = self.api_base + 'friends/ids.json';
+        var url = self.api_base_url(1.1) + 'friends/ids.json';
         var params = {
             'screen_name': screen_name,
             'cursor': cursor
@@ -459,12 +488,14 @@ function TwitterClient() {
     };
 
     self.get_user_profile_image = function get_user_profile_image(screen_name, size) {
-        var url = self.api_base + 'users/profile_image/twitter.json' + '?size=' + size + '&screen_name=' + screen_name + '&rnd=' + Math.random();
+        var url = self.api_base_url(1) + 'users/profile_image/twitter.json' + '?size=' + size + '&screen_name=' + screen_name + '&rnd=' + Math.random();
         return url;
+
+        // has been removed in API v1.1
     };
 
     self.update_profile_image = function update_profile_image(file, file_data, on_success) {
-        var url = self.api_base + 'account/update_profile_image.json';
+        var url = self.api_base_url(1.1) + 'account/update_profile_image.json';
         var signed_params = self.oauth.form_signed_params(
         url, self.oauth.access_token, 'POST', {},
         true);
@@ -484,7 +515,7 @@ function TwitterClient() {
     };
 
     self.update_profile = function update_profile(name, website, location, description, on_success) {
-        var url = self.api_base + 'account/update_profile.json';
+        var url = self.api_base_url(1.1) + 'account/update_profile.json';
         var params = {
             'name': name,
             'website': website,
@@ -495,16 +526,19 @@ function TwitterClient() {
     };
 
     self.exists_friendships = function exists_friendships(source, target, on_success) {
-        var url = self.api_base + 'friendships/exists.json';
+        var url = self.api_base_url(1) + 'friendships/exists.json';
         var params = {
             'user_a': source,
             'user_b': target
         };
         self.get(url, params, on_success);
+
+        // has been removed in API v1.1
+        // can use show_friendships instead
     };
 
     self.show_friendships = function show_friendships(source, target, on_success) {
-        var url = self.api_base + 'friendships/show.json';
+        var url = self.api_base_url(1.1) + 'friendships/show.json';
         var params = {
             'source_screen_name': source,
             'target_screen_name': target
@@ -513,7 +547,7 @@ function TwitterClient() {
     };
 
     self.create_friendships = function create_friendships(screen_name, on_success) {
-        var url = self.api_base + 'friendships/create.json';
+        var url = self.api_base_url(1.1) + 'friendships/create.json';
         var params = {
             'screen_name': screen_name,
             'follow': 'true'
@@ -522,7 +556,7 @@ function TwitterClient() {
     };
 
     self.destroy_friendships = function destroy_friendships(screen_name, on_success) {
-        var url = self.api_base + 'friendships/destroy.json';
+        var url = self.api_base_url(1.1) + 'friendships/destroy.json';
         var params = {
             'screen_name': screen_name
         };
@@ -530,16 +564,16 @@ function TwitterClient() {
     };
 
     self.create_blocks = function create_blocks(screen_name, on_success) {
-        var url = self.api_base + 'blocks/create.json';
+        var url = self.api_base_url(1.1) + 'blocks/create.json';
         var params = {
             'screen_name': screen_name,
-            'follow': 'true'
+            'follow': 'true'            // undocumented argument but kept
         };
         self.post(url, params, on_success);
     };
 
     self.destroy_blocks = function destroy_blocks(screen_name, on_success) {
-        var url = self.api_base + 'blocks/destroy.json';
+        var url = self.api_base_url(1.1) + 'blocks/destroy.json';
         var params = {
             'screen_name': screen_name
         };
@@ -547,7 +581,7 @@ function TwitterClient() {
     };
 
     self.get_blocking_ids = function get_blocking_ids(cursor, on_success, on_error) {
-        var url = self.api_base + 'blocks/blocking/ids.json';
+        var url = self.api_base_url(1.1) + 'blocks/ids.json';
         var params = {
             'stringify_ids': true,
             'cursor': cursor
@@ -556,7 +590,7 @@ function TwitterClient() {
     };
 
     self.get_user_listed_lists = function get_listed_lists(screen_name, cursor, on_success) {
-        var url = self.api_base + 'lists/memberships.json';
+        var url = self.api_base_url(1.1) + 'lists/memberships.json';
         var params = {
             'screen_name': screen_name,
             'cursor': cursor
@@ -565,7 +599,7 @@ function TwitterClient() {
     };
 
     self.get_user_lists = function get_user_lists(screen_name, cursor, on_success) {
-        var url = self.api_base + 'lists.json';
+        var url = self.api_base_url(1.1) + 'lists/list.json';
         var params = {
             'screen_name': screen_name,
             'cursor': cursor
@@ -574,7 +608,7 @@ function TwitterClient() {
     };
 
     self.get_list_statuses = function get_list_statuses(owner_screen_name, slug, since_id, max_id, on_success, on_error) {
-        var url = self.api_base + 'lists/statuses.json';
+        var url = self.api_base_url(1.1) + 'lists/statuses.json';
         var params = {
             'include_entities': '1',
             'include_rts': '1',
@@ -587,7 +621,7 @@ function TwitterClient() {
     };
 
     self.get_list_subscribers = function get_list_subscribers(owner_screen_name, slug, cursor, on_success) {
-        var url = self.api_base + 'lists/subscribers.json';
+        var url = self.api_base_url(1.1) + 'lists/subscribers.json';
         var params = {
             'include_entities': '1',
             'owner_screen_name': owner_screen_name,
@@ -598,7 +632,7 @@ function TwitterClient() {
     };
 
     self.get_list_members = function get_list_members(owner_screen_name, slug, cursor, on_success) {
-        var url = self.api_base + 'lists/members.json';
+        var url = self.api_base_url(1.1) + 'lists/members.json';
         var params = {
             'include_entities': '1',
             'owner_screen_name': owner_screen_name,
@@ -609,7 +643,7 @@ function TwitterClient() {
     };
 
     self.create_list_member = function create_list_member(id, screen_name, on_success, on_error) {
-        var url = self.api_base + 'lists/members/create.json';
+        var url = self.api_base_url(1.1) + 'lists/members/create.json';
         var params = {
             'list_id': id,
             'screen_name': screen_name
@@ -618,7 +652,7 @@ function TwitterClient() {
     };
 
     self.destroy_list_member = function destroy_list_member(owner_screen_name, slug, screen_name, on_success) {
-        var url = self.api_base + 'lists/members/destroy.json';
+        var url = self.api_base_url(1.1) + 'lists/members/destroy.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug,
@@ -628,7 +662,7 @@ function TwitterClient() {
     };
 
     self.create_list_subscriber = function create_list_subscriber(owner_screen_name, slug, on_success) {
-        var url = self.api_base + 'lists/subscribers/create.json';
+        var url = self.api_base_url(1.1) + 'lists/subscribers/create.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug
@@ -637,7 +671,7 @@ function TwitterClient() {
     };
 
     self.destroy_list_subscriber = function destroy_list_subscriber(owner_screen_name, slug, on_success) {
-        var url = self.api_base + 'lists/subscribers/destroy.json';
+        var url = self.api_base_url(1.1) + 'lists/subscribers/destroy.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug
@@ -646,7 +680,7 @@ function TwitterClient() {
     };
 
     self.create_list = function create_list(slug, description, mode, on_success) {
-        var url = self.api_base + 'lists/create.json';
+        var url = self.api_base_url(1.1) + 'lists/create.json';
         var params = {
             'name': slug,
             'mode': mode,
@@ -656,7 +690,7 @@ function TwitterClient() {
     };
 
     self.destroy_list = function destroy_list(owner_screen_name, slug, on_success) {
-        var url = self.api_base + 'lists/destroy.json';
+        var url = self.api_base_url(1.1) + 'lists/destroy.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug
@@ -665,7 +699,7 @@ function TwitterClient() {
     };
 
     self.show_list = function show_list(owner_screen_name, slug, on_success, on_error) {
-        var url = self.api_base + 'lists/show.json';
+        var url = self.api_base_url(1.1) + 'lists/show.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug
@@ -674,7 +708,7 @@ function TwitterClient() {
     };
 
     self.update_list = function update_list(owner_screen_name, slug, description, mode, on_success, on_error) {
-        var url = self.api_base + 'lists/update.json';
+        var url = self.api_base_url(1.1) + 'lists/update.json';
         var params = {
             'owner_screen_name': owner_screen_name,
             'slug': slug,
@@ -685,13 +719,13 @@ function TwitterClient() {
     };
 
     self.verify = function verify(on_success, on_error) {
-        var url = self.api_base + 'account/verify_credentials.json';
+        var url = self.api_base_url(1.1) + 'account/verify_credentials.json';
         self.get(url, {},
         on_success, on_error);
     };
 
     self.create_saved_search = function create_saved_search(query, on_success, on_error) {
-        var url = self.api_base + 'saved_searches/create.json';
+        var url = self.api_base_url(1.1) + 'saved_searches/create.json';
         self.post(url, {
             'query': query
         },
@@ -700,14 +734,14 @@ function TwitterClient() {
     };
 
     self.destroy_saved_search = function create_saved_search(id, on_success, on_error) {
-        var url = self.api_base + 'saved_searches/destroy/' + id + '.json';
+        var url = self.api_base_url(1.1) + 'saved_searches/destroy/' + id + '.json';
         self.post(url, {},
         on_success, on_error);
         return;
     };
 
     self.get_saved_searches = function get_saved_searches(on_success, on_error) {
-        var url = self.api_base + 'saved_searches.json';
+        var url = self.api_base_url(1.1) + 'saved_searches.json';
         self.get(url, {},
         on_success, on_error);
         return;
@@ -772,7 +806,7 @@ function TwitterClient() {
     self.abort_watch_user_streams = function abort_watch_user_streams() {};
 
     self.watch_user_streams = function watch_user_streams(callback) {
-        if (!self.use_oauth || watch_user_streams.is_running || watch_user_streams.disable || self.api_base.indexOf('https://api.twitter.com/') < 0) {
+        if (!self.use_oauth || watch_user_streams.is_running || watch_user_streams.disable || self.api_base_url(1).indexOf('https://api.twitter.com/') < 0) {
             return;
         }
         if (!watch_user_streams.times) {
@@ -898,4 +932,3 @@ function TwitterClient() {
 };
 
 lib.twitter.Client = TwitterClient;
-


### PR DESCRIPTION
There are some APIs that have been removed in API v1.1:
- get_user_profile_image
- exists_friendships
- get_retweeted_to_me
- get_retweeted_by_me

Some API like _exists_friendships_ can use other API instead.
But I can't find replacements for the following API:
- get_retweeted_to_me
- get_retweeted_by_me

API _get_user_lists_ (v1.1) may cause too many requested, some changes in other place will be required to fix this bug, I'll fix it later.
