### PR TITLE
Fix Issue #482

### DIFF
--- a/data/js/ui.template.js
+++ b/data/js/ui.template.js
@@ -771,6 +771,7 @@ function form_tweet (tweet_obj, pagename, in_thread) {
     var id = tweet_obj.id_str;
     if (tweet_obj.hasOwnProperty('retweeted_status')) {
         retweet_name = tweet_obj['user']['screen_name'];
+        tweet_obj['retweeted_status'].favorited = tweet_obj.favorited;  // The favorite status of the embedded tweet is not reliable, use outer one.
         tweet_obj = tweet_obj['retweeted_status'];
         retweet_id = tweet_obj.id_str;
     }
@@ -913,6 +914,7 @@ function form_retweeted_by(tweet_obj, pagename) {
     var id = tweet_obj.id_str;
     if (tweet_obj.hasOwnProperty('retweeted_status')) {
         retweet_name = tweet_obj['user']['screen_name'];
+        tweet_obj['retweeted_status'].favorited = tweet_obj.favorited;  // The favorite status of the embedded tweet is not reliable, use outer one.
         tweet_obj = tweet_obj['retweeted_status'];
         retweet_id = tweet_obj.id_str;
     }


### PR DESCRIPTION
Perspectival boolean attributes in timelines like these are "best
effort", especially for embedded tweets. After some tests, I found that
the outer values seems more reliable, so I copied them to the embedded
one.

See https://gist.github.com/leafduo/5023250 for a test case.
This JSON object was captured from streaming api after @yukixz
favorited and retweeted the original tweet. The favorite field of
embedded tweet is `true`, which was _wrong_ since I didn't favorited
that. But the outer one was correct. BTW, after a short period of
time, the one in embedded tweet became `false`, which was correct.
So, this may be an issue trading consistency for scalability.

Useful links:
https://dev.twitter.com/discussions/11632
https://dev.twitter.com/discussions/14351

BTW: Why 2 copies duplicated code? Extract them? I don't read through all code, so if I'm wrong, correct me.
