### PR TITLE
Added Fix for sometimes broken Chrome detection

### DIFF
--- a/data/js/conf.js
+++ b/data/js/conf.js
@@ -267,10 +267,14 @@ function apply_settings() {
     $('.version').text(conf.vars.version 
         + ' (' + conf.vars.codename + ')');
     if (conf.vars.platform === 'Chrome') {
+        try {
         chrome.extension.sendRequest(
             {'enableContextMenu':conf.settings.context_menu_integration},
             function (resp) {}
         );
+        }
+        catch(err){
+        }
     }
     globals.twitterClient.oauth.key = localStorage.consumer_key || conf.vars.consumer_key;
     globals.twitterClient.oauth.secret = localStorage.consumer_secret || conf.vars.consumer_secret;


### PR DESCRIPTION
For some reason the chrome integration triggers with certain webkit
versions in the GTK (and maybe Qt) application.

The startup hangs at "Loading Resources" because a reference to "chrome"
cannot be resolved and triggers an uncaught exception locking up the
startup.

I wrapped the call to chrome in a try{} catch{} block to make it pass.
Shouldn't break any chrome integration but will get unchromy things to
startup properly.
